### PR TITLE
Upgrade pyparsing utilization

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -87,7 +87,7 @@ To get flake8, isort and tox, just pip install them into your virtualenv.
 
 6. Build the doc::
 
-    $ python setup doc
+    $ python setup.py doc
 
 check the resulting html in docs/build/html/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+setup: ## Command to setup the project
+	pip install -r requirements.txt
+	python setup.py develop
+
+tests: ## Starts the CI pipeline
+	tox
+ 
+lint: ## Check for isort and flake8 rules
+	flake8 src tests
+	isort src
+
+doc: ## Generate doc with Sphinx
+	python setup.py doc
+
+.PHONY: tests
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-coverage==4.3.4
-flake8==3.3.0
-isort==4.2.5
+coverage==6.1.2
+flake8==4.0.1
+isort== 5.10.1
 nose==1.3.7
-Sphinx==1.5.5
-tox==2.7.0
-pyparsing >= 1.5.2
+Sphinx==4.3.0
+tox==3.24.4
+pyparsing >= 3.0.6
 six

--- a/src/booleano/__init__.py
+++ b/src/booleano/__init__.py
@@ -31,7 +31,8 @@
 from __future__ import unicode_literals
 
 try:  # pragma: no cover
-    __import__('pkg_resources').declare_namespace(__name__)
+    __import__("pkg_resources").declare_namespace(__name__)
 except ImportError:  # pragma: no cover
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/booleano/exc.py
+++ b/src/booleano/exc.py
@@ -13,6 +13,7 @@ class BooleanoException(Exception):
     exception raised by Booleano.
 
     """
+
     pass
 
 
@@ -30,6 +31,7 @@ class InvalidOperationError(BooleanoException):
     For example: ``"word" > 10``.
 
     """
+
     pass
 
 
@@ -38,6 +40,7 @@ class BadCallError(InvalidOperationError):
     Exception raised when a function is called with wrong parameters.
 
     """
+
     pass
 
 
@@ -49,6 +52,7 @@ class BadOperandError(BooleanoException):
     translatable.
 
     """
+
     pass
 
 
@@ -60,6 +64,7 @@ class BadFunctionError(BadOperandError):
     translatable.
 
     """
+
     pass
 
 
@@ -74,6 +79,7 @@ class ParsingException(BooleanoException):
     exception raised by the parser.
 
     """
+
     pass
 
 
@@ -83,16 +89,19 @@ class GrammarError(ParsingException):
     made to use it incorrectly.
 
     """
+
     pass
 
 
 class BadExpressionError(ParsingException):
     """Exception raised when a expression is not a valid boolean expression."""
+
     pass
 
 
 class ScopeError(ParsingException):
     """Exception raised when a scope-related item is defined incorrectly."""
+
     pass
 
 
@@ -105,4 +114,5 @@ class ConversionError(BooleanoException):
     was passed.
 
     """
+
     pass

--- a/src/booleano/operations/__init__.py
+++ b/src/booleano/operations/__init__.py
@@ -44,9 +44,24 @@ from booleano.operations.operators import (And, BelongsTo, Equal, GreaterEqual, 
 
 __all__ = (
     # Operands:
-    "String", "Number", "Set", "Variable", "Function", "PlaceholderVariable",
+    "String",
+    "Number",
+    "Set",
+    "Variable",
+    "Function",
+    "PlaceholderVariable",
     "PlaceholderFunction",
     # Operators:
-    "Not", "And", "Or", "Xor", "Equal", "NotEqual", "LessThan", "GreaterThan",
-    "LessEqual", "GreaterEqual", "BelongsTo", "IsSubset",
+    "Not",
+    "And",
+    "Or",
+    "Xor",
+    "Equal",
+    "NotEqual",
+    "LessThan",
+    "GreaterThan",
+    "LessEqual",
+    "GreaterEqual",
+    "BelongsTo",
+    "IsSubset",
 )

--- a/src/booleano/operations/converters.py
+++ b/src/booleano/operations/converters.py
@@ -38,7 +38,7 @@ from booleano.operations.operands.placeholders import PlaceholderFunction, Place
 from booleano.operations.operators import (And, BelongsTo, Equal, GreaterEqual, GreaterThan, IsSubset, LessEqual,
                                            LessThan, Not, NotEqual, Or, UnaryOperator, Xor)
 
-__all__ = ("BaseConverter", )
+__all__ = ("BaseConverter",)
 
 
 class BaseConverter(object):
@@ -114,8 +114,7 @@ class BaseConverter(object):
             return convert(node.constant_value)
 
         if isinstance(node, Set):
-            elements = [self.convert(element) for element
-                        in node.constant_value]
+            elements = [self.convert(element) for element in node.constant_value]
             return convert(*elements)
 
         if isinstance(node, PlaceholderFunction):

--- a/src/booleano/operations/core.py
+++ b/src/booleano/operations/core.py
@@ -24,6 +24,7 @@ class OperationNode(object):
     It can also be seen as the base class for each node in the parse trees.
 
     """
+
     _is_leaf = None
 
     def __call__(self, context):
@@ -63,7 +64,9 @@ class OperationNode(object):
         :class:`PlaceholderVariable`.
 
         """
-        assert self._is_leaf is not None, "subclass of OperationNode must provide _is_leaf with true or false"
+        assert (
+            self._is_leaf is not None
+        ), "subclass of OperationNode must provide _is_leaf with true or false"
         return self._is_leaf
 
     def is_branch(self):
@@ -110,8 +113,7 @@ class OperationNode(object):
 
         """
         error_msg = 'Nodes "%s" and "%s" are not equivalent'
-        assert isinstance(node, self.__class__), error_msg % (repr(node),
-                                                              repr(self))
+        assert isinstance(node, self.__class__), error_msg % (repr(node), repr(self))
 
     def __hash__(self):
         return id(self)
@@ -129,8 +131,9 @@ class OperationNode(object):
         Operation nodes must be evaluated passing the context explicitly.
 
         """
-        raise InvalidOperationError("Operation nodes do not support Pythonic "
-                                    "truth evaluation")
+        raise InvalidOperationError(
+            "Operation nodes do not support Pythonic " "truth evaluation"
+        )
 
     __nonzero__ = __bool__
 
@@ -178,5 +181,6 @@ class OperationNode(object):
         representation explicitly.
 
         """
-        raise NotImplementedError("Node %s doesn't have an "
-                                  "representation" % type(self))
+        raise NotImplementedError(
+            "Node %s doesn't have an " "representation" % type(self)
+        )

--- a/src/booleano/operations/operands/__init__.py
+++ b/src/booleano/operations/operands/__init__.py
@@ -35,5 +35,12 @@ from booleano.operations.operands.classes import Function, Variable
 from booleano.operations.operands.constants import Number, Set, String
 from booleano.operations.operands.placeholders import PlaceholderFunction, PlaceholderVariable
 
-__all__ = ("String", "Number", "Set", "Variable", "Function",
-           "PlaceholderVariable", "PlaceholderFunction")
+__all__ = (
+    "String",
+    "Number",
+    "Set",
+    "Variable",
+    "Function",
+    "PlaceholderVariable",
+    "PlaceholderFunction",
+)

--- a/src/booleano/operations/operands/core.py
+++ b/src/booleano/operations/operands/core.py
@@ -40,39 +40,42 @@ class _OperandMeta(type):
 
         """
         if not cls.operations.issubset(OPERATIONS):
-            raise BadOperandError("Operand %s supports unknown operations" %
-                                  name)
+            raise BadOperandError("Operand %s supports unknown operations" % name)
         if len(cls.operations) == 0:
-            raise BadOperandError("Operand %s must support at least one "
-                                  "operation" % name)
+            raise BadOperandError(
+                "Operand %s must support at least one " "operation" % name
+            )
         if not cls.is_implemented(cls.to_python):
-            raise BadOperandError("Operand %s must define the .to_python() "
-                                  "method" % name)
+            raise BadOperandError(
+                "Operand %s must define the .to_python() " "method" % name
+            )
         # Checking the operations supported:
-        if ("boolean" in cls.operations and
-                not cls.is_implemented(cls.__call__)):
-            raise BadOperandError("Operand %s must return its truth value "
-                                  "through .__call__() method" % name)
+        if "boolean" in cls.operations and not cls.is_implemented(cls.__call__):
+            raise BadOperandError(
+                "Operand %s must return its truth value "
+                "through .__call__() method" % name
+            )
         if "equality" in cls.operations and not cls.is_implemented(cls.equals):
-            raise BadOperandError("Operand %s must define the .equals() "
-                                  "method because it supports equalities" %
-                                  name)
-        if (
-            "inequality" in cls.operations and not (
-                cls.is_implemented(cls.less_than) and
-                cls.is_implemented(cls.greater_than))
+            raise BadOperandError(
+                "Operand %s must define the .equals() "
+                "method because it supports equalities" % name
+            )
+        if "inequality" in cls.operations and not (
+            cls.is_implemented(cls.less_than) and cls.is_implemented(cls.greater_than)
         ):
-            raise BadOperandError("Operand %s must define the .greater_than() "
-                                  "and .less_than() methods because it "
-                                  "supports inequalities" % name)
-        if (
-            "membership" in cls.operations and not (
-                cls.is_implemented(cls.belongs_to) and
-                cls.is_implemented(cls.is_subset))
+            raise BadOperandError(
+                "Operand %s must define the .greater_than() "
+                "and .less_than() methods because it "
+                "supports inequalities" % name
+            )
+        if "membership" in cls.operations and not (
+            cls.is_implemented(cls.belongs_to) and cls.is_implemented(cls.is_subset)
         ):
-            raise BadOperandError("Operand %s must define the .belongs_to() "
-                                  "and .is_subset() methods because it "
-                                  "supports memberships" % name)
+            raise BadOperandError(
+                "Operand %s must define the .belongs_to() "
+                "and .is_subset() methods because it "
+                "supports memberships" % name
+            )
 
     def is_implemented(cls, method):
         """Check that ``method`` is implemented."""
@@ -113,6 +116,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     to_python.implemented = False
 
     def check_operation(self, operation):
@@ -127,8 +131,9 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
         """
         if operation in self.operations:
             return
-        raise InvalidOperationError('Operand "%s" does not support operation '
-                                    '"%s"' % (repr(self), operation))
+        raise InvalidOperationError(
+            'Operand "%s" does not support operation ' '"%s"' % (repr(self), operation)
+        )
 
     # Unary operations
 
@@ -145,6 +150,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     __call__.implemented = False
 
     # Binary operations
@@ -160,6 +166,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     equals.implemented = False
 
     def greater_than(self, value, context):
@@ -173,6 +180,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     greater_than.implemented = False
 
     def less_than(self, value, context):
@@ -186,6 +194,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     less_than.implemented = False
 
     def belongs_to(self, value, context):
@@ -199,6 +208,7 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     belongs_to.implemented = False
 
     def is_subset(self, value, context):
@@ -212,4 +222,5 @@ class Operand(six.with_metaclass(_OperandMeta, OperationNode)):
 
         """
         raise NotImplementedError
+
     is_subset.implemented = False

--- a/src/booleano/operations/operands/placeholders.py
+++ b/src/booleano/operations/operands/placeholders.py
@@ -78,8 +78,7 @@ class PlaceholderInstance(Operand):
         """
         super(PlaceholderInstance, self).check_equivalence(node)
         assert (
-            self.name == node.name and
-            self.namespace_parts == node.namespace_parts), \
+            self.name == node.name and self.namespace_parts == node.namespace_parts), \
             'Placeholders "%s" and "%s" are not equivalent' % (self, node)
 
     def no_evaluation(self, *args, **kwargs):

--- a/src/booleano/operations/operators.py
+++ b/src/booleano/operations/operators.py
@@ -191,14 +191,12 @@ class BinaryOperator(Operator):
 
         """
         super(BinaryOperator, self).check_equivalence(node)
+        is_same_master = node.master_operand == self.master_operand
+        is_same_slave = node.slave_operand == self.slave_operand
+        node_master_slave = node.master_operand == self.slave_operand
+        node_slave_master = self.master_operand == node.slave_operand
         same_operands = (
-            (
-                node.master_operand == self.master_operand and
-                node.slave_operand == self.slave_operand
-            ) or (
-                node.master_operand == self.slave_operand and
-                self.master_operand == node.slave_operand
-            )
+            (is_same_master and is_same_slave) or (node_master_slave and node_slave_master)
         )
         assert same_operands, 'Operands of binary operations %s and %s are not equivalent' % (
             node,

--- a/src/booleano/operations/variables.py
+++ b/src/booleano/operations/variables.py
@@ -25,10 +25,11 @@ class NativeVariable(Variable):
     it can be lazy if the given context_name is a callable, in this case, the callable
     will be called with the current context
     """
+
     operations = {
-        "equality",           # ==, !=
-        "inequality",         # >, <, >=, <=
-        "boolean",            # Logical values
+        "equality",  # ==, !=
+        "inequality",  # >, <, >=, <=
+        "boolean",  # Logical values
     }
 
     def __init__(self, context_name):
@@ -80,11 +81,17 @@ class NativeVariable(Variable):
 
     def __str__(self):
         """Return the Unicode representation of this variable."""
-        return 'Scop variable for %s [%s]' % (self.context_name, self.__class__.__name__)
+        return "Scop variable for %s [%s]" % (
+            self.context_name,
+            self.__class__.__name__,
+        )
 
     def __repr__(self):
         """Represent this variable."""
-        return '<Scop variable for %s [%s]>' % (self.context_name, self.__class__.__name__)
+        return "<Scop variable for %s [%s]>" % (
+            self.context_name,
+            self.__class__.__name__,
+        )
 
 
 @variable_symbol_table_builder.register(list)
@@ -176,12 +183,13 @@ class FormatableVariable(NativeVariable):
     """
     a class that accept a extra format in his constructor
     """
+
     formats = []
 
     def __init__(self, context_name, formats=None):
 
         if isinstance(formats, six.text_type):
-            self.formats = (formats, )
+            self.formats = (formats,)
         elif formats is not None:
             self.formats = formats
         super(FormatableVariable, self).__init__(context_name)
@@ -204,20 +212,19 @@ class DurationVariable(FormatableVariable):
 
 
     """
+
     formats = [
         (
-            r'^((?P<days>\d+?) ?d(ays)?)? *'
-            r'((?P<hours>\d+?) ?h(r|ours?)?)? *'
-            r'((?P<minutes>\d+?) ?m(inutes)?)? *'
-            r'((?P<seconds>\d+?) ?s(econds)?)? *$'
+            r"^((?P<days>\d+?) ?d(ays)?)? *"
+            r"((?P<hours>\d+?) ?h(r|ours?)?)? *"
+            r"((?P<minutes>\d+?) ?m(inutes)?)? *"
+            r"((?P<seconds>\d+?) ?s(econds)?)? *$"
         )
     ]
 
     def __init__(self, context_name, formats=None):
         super(DurationVariable, self).__init__(context_name, formats)
-        self.regexps = [
-            re.compile(regex) for regex in self.formats
-        ]
+        self.regexps = [re.compile(regex) for regex in self.formats]
 
     def _from_native_string(self, value):
         """
@@ -229,7 +236,11 @@ class DurationVariable(FormatableVariable):
         for regex in self.regexps:
             match = regex.search(value)
             if match:
-                res = {unit: int(val) for unit, val in match.groupdict().items() if val is not None}
+                res = {
+                    unit: int(val)
+                    for unit, val in match.groupdict().items()
+                    if val is not None
+                }
                 if res:
                     return datetime.timedelta(**res)
         raise ValueError("bad date format for %s: tied %r" % (value, self.formats))
@@ -296,12 +307,8 @@ class DateVariable(DateTimeVariable):
         DateVariable("context_name", formats=["%Y %m %d"])
 
     """
-    formats = (
-        "%d/%m/%Y",
-        "%d-%m-%Y",
-        "%Y/%m/%d",
-        "%Y-%m-%d",
-    )
+
+    formats = ("%d/%m/%Y", "%d-%m-%Y", "%Y/%m/%d", "%Y-%m-%d")
 
     def _from_native_string(self, value):
         return super(DateVariable, self)._from_native_string(value).date()

--- a/src/booleano/parser/__init__.py
+++ b/src/booleano/parser/__init__.py
@@ -35,5 +35,4 @@ from __future__ import unicode_literals
 from booleano.parser.grammar import Grammar
 from booleano.parser.scope import Bind, SymbolTable
 
-__all__ = ("Grammar",
-           "Bind", "SymbolTable")
+__all__ = ("Grammar", "Bind", "SymbolTable")

--- a/src/booleano/parser/core.py
+++ b/src/booleano/parser/core.py
@@ -87,8 +87,7 @@ class ParseManager(object):
 
         """
         if locale in self._parsers:
-            raise GrammarError("There is already a parser for grammar %s" %
-                               locale)
+            raise GrammarError("There is already a parser for grammar %s" % locale)
         parser = self._define_parser(locale, grammar)
         self._parsers[locale] = parser
 
@@ -122,8 +121,7 @@ class ParseManager(object):
         :rtype: Parser
 
         """
-        raise NotImplementedError("Actual parse managers must define their "
-                                  "parsers")
+        raise NotImplementedError("Actual parse managers must define their " "parsers")
 
         #
 
@@ -136,8 +134,9 @@ class EvaluableParseManager(ParseManager):
 
     """
 
-    def __init__(self, symbol_table, generic_grammar, cache_limit=0,
-                 **localized_grammars):
+    def __init__(
+        self, symbol_table, generic_grammar, cache_limit=0, **localized_grammars
+    ):
         """
 
         :param symbol_table: The symbol table for the supported expressions.
@@ -153,9 +152,9 @@ class EvaluableParseManager(ParseManager):
 
         """
         self._symbol_table = symbol_table
-        super(EvaluableParseManager, self).__init__(generic_grammar,
-                                                    cache_limit,
-                                                    **localized_grammars)
+        super(EvaluableParseManager, self).__init__(
+            generic_grammar, cache_limit, **localized_grammars
+        )
 
     def evaluate(self, expression, locale, context):
         """
@@ -330,8 +329,9 @@ class _Cache(object):
         been reached or there's nothing cached.
 
         """
-        if (self.limit is None or self.counter < self.limit or
-                not self.latest_expressions):
+        if (
+            self.limit is None or self.counter < self.limit or not self.latest_expressions
+        ):
             return
         (locale, expression) = self.latest_expressions.pop(-1)
         del self.cache_by_locale[locale][expression]

--- a/src/booleano/parser/parsers.py
+++ b/src/booleano/parser/parsers.py
@@ -29,7 +29,6 @@
 Generic Pyparsing-based parser implementation.
 
 """
-
 from __future__ import unicode_literals
 
 import re
@@ -37,8 +36,8 @@ import re
 import six
 import six.moves
 from pyparsing import (CaselessLiteral, Combine, Forward, Group, Literal, OneOrMore, Optional, ParserElement, Regex,
-                       StringEnd, StringStart, Suppress, Word, ZeroOrMore, delimitedList, nums, opAssoc,
-                       operatorPrecedence, quotedString, removeQuotes)
+                       StringEnd, StringStart, Suppress, Word, ZeroOrMore, delimitedList, infixNotation, nums, opAssoc,
+                       quotedString, removeQuotes)
 
 from booleano.exc import BadExpressionError
 from booleano.operations.operands.classes import Function
@@ -148,7 +147,7 @@ class Parser(object):
 
         operand = self.define_operand()
 
-        operation = operatorPrecedence(
+        operation = infixNotation(
             operand,
             [
                 (relationals, 2, opAssoc.LEFT, self.make_relational),
@@ -207,8 +206,7 @@ class Parser(object):
         function.setName("function")
         function.setParseAction(self.make_function)
 
-        operand << (function | variable | self.define_number() |
-                    self.define_string() | set_)
+        operand << (function | variable | self.define_number() | self.define_string() | set_)
 
         return operand
 
@@ -278,7 +276,7 @@ class Parser(object):
                                    if six.unichr(n).isdigit()])
         unicode_number_expr = Regex("[%s]" % unicode_numbers, re.UNICODE)
         space_char = re.escape(self._grammar.get_token("identifier_spacing"))
-        identifier0 = Regex("[\w%s]+" % space_char, re.UNICODE)
+        identifier0 = Regex("[\w%s]+" % space_char, re.UNICODE)  # noqa: W605
         # Identifiers cannot start with a number:
         identifier0 = Combine(~unicode_number_expr + identifier0)
         identifier0.setName("individual_identifier")
@@ -289,8 +287,7 @@ class Parser(object):
         namespace.setName("namespace")
 
         # --- The full identifier, which could have a namespace:
-        identifier = Combine(namespace.setResultsName("namespace_parts") +
-                             identifier0.setResultsName("identifier"))
+        identifier = Combine(namespace.setResultsName("namespace_parts") + identifier0.setResultsName("identifier"))
         identifier.setName("full_identifier")
 
         return identifier

--- a/src/booleano/parser/scope.py
+++ b/src/booleano/parser/scope.py
@@ -120,9 +120,7 @@ class _Identifier(object):
         Two identifiers are equivalent if the have the same names.
 
         """
-        if (isinstance(other, _Identifier) and
-                self.global_name == other.global_name and
-                self.names == other.names):
+        if (isinstance(other, _Identifier) and self.global_name == other.global_name and self.names == other.names):
             return True
         return False
 
@@ -384,11 +382,11 @@ class SymbolTable(_Identifier):
 
         """
         same_id = super(SymbolTable, self).__eq__(other)
-        return (same_id and
-                hasattr(other, "subtables") and
-                hasattr(other, "objects") and
-                other.subtables == self.subtables and
-                self.objects == other.objects)
+        is_subtables = other.subtables == self.subtables
+        is_objects = self.objects == other.objects
+        return (
+            same_id and hasattr(other, "subtables") and hasattr(other, "objects") and is_subtables and is_objects
+        )
 
     def __hash__(self):
         return hash((frozenset(getattr(self, 'subtables', set())), frozenset(getattr(self, 'objects', set()))))

--- a/src/booleano/parser/symbol_table_builder.py
+++ b/src/booleano/parser/symbol_table_builder.py
@@ -28,7 +28,10 @@ class SymbolTableBuilder(object):
 
     def register(self, type_, variable_class=None):
         if type_ in self.registered_variables:
-            raise Exception("the type %s is arleady registered to %s" % (type_, self.registered_variables[type_]))
+            raise Exception(
+                "the type %s is arleady registered to %s"
+                % (type_, self.registered_variables[type_])
+            )
 
         if variable_class is not None:
             self.registered_variables[type_] = variable_class
@@ -55,8 +58,10 @@ class SymbolTableBuilder(object):
                 if found is None or len(found.__mro__) < len(registered_type.__mro__):
                     found = registered_type
         if found is None:
-            raise Exception("the type of data %(type)s has no registered variable type. "
-                            "try to use @symbol_table_builder.register(%(type)s)" % dict(type=type_))
+            raise Exception(
+                "the type of data %(type)s has no registered variable type. "
+                "try to use @symbol_table_builder.register(%(type)s)" % dict(type=type_)
+            )
         return self.registered_variables[found]
 
     def __call__(self, name, sample):
@@ -75,7 +80,5 @@ class SymbolTableBuilder(object):
 
             var = self.find_for_type(var_type)
 
-            binds.append(
-                Bind(k, var(k if self.use_key else v))
-            )
+            binds.append(Bind(k, var(k if self.use_key else v)))
         return SymbolTable(name, binds)

--- a/src/booleano/parser/testutils.py
+++ b/src/booleano/parser/testutils.py
@@ -36,7 +36,7 @@ from pyparsing import ParseException
 
 from booleano.parser.parsers import ConvertibleParser
 
-__all__ = ("BaseGrammarTest", )
+__all__ = ("BaseGrammarTest",)
 
 
 class BaseGrammarTest(object):
@@ -102,8 +102,11 @@ class BaseGrammarTest(object):
             def check():
                 tree = self.parser(expression)
                 expected_node.check_equivalence(tree.root_node)
-            check.description = 'Operation "%s" should yield "%s"' % \
-                                (repr(expression), expected_node)
+
+            check.description = 'Operation "%s" should yield "%s"' % (
+                repr(expression),
+                expected_node,
+            )
 
             yield check
 
@@ -115,6 +118,7 @@ class BaseGrammarTest(object):
             @raises(ParseException)
             def check():
                 self.parser(expression)
+
             check.description = "'%s' is an invalid expression" % expression
 
             yield check
@@ -133,8 +137,11 @@ class BaseGrammarTest(object):
                 node = operand_parser(expression, parseAll=True)
                 eq_(1, len(node))
                 expected_operand.check_equivalence(node[0])
-            check.description = ('Single operand "%s" should return %s' %
-                                 (expression, expected_operand))
+
+            check.description = 'Single operand "%s" should return %s' % (
+                expression,
+                expected_operand,
+            )
 
             yield check
 
@@ -150,7 +157,7 @@ class BaseGrammarTest(object):
             @raises(ParseException)
             def check():
                 operand_parser(expression, parseAll=True)
-            check.description = ('"%s" is an invalid operand' %
-                                 expression)
+
+            check.description = '"%s" is an invalid operand' % expression
 
             yield check

--- a/src/booleano/parser/trees.py
+++ b/src/booleano/parser/trees.py
@@ -63,8 +63,7 @@ class ParseTree(object):
         Check if the ``other`` parse tree is equivalent to this one.
 
         """
-        return (isinstance(other, self.__class__) and
-                other.root_node == self.root_node)
+        return isinstance(other, self.__class__) and other.root_node == self.root_node
 
     def __hash__(self):
         return id(self)

--- a/src/booleano/utils.py
+++ b/src/booleano/utils.py
@@ -11,7 +11,9 @@ from booleano.parser.grammar import Grammar
 logger = logging.getLogger(__name__)
 
 
-def get_boolean_evaluator(statment, variables=None, constants=None, grammar_tokens=None):
+def get_boolean_evaluator(
+    statment, variables=None, constants=None, grammar_tokens=None
+):
     """
     an fast and easy to use helper to build a parser with variables and constants.
     return a callable which take a dict of value (for the variables).
@@ -33,13 +35,11 @@ def get_boolean_evaluator(statment, variables=None, constants=None, grammar_toke
     if variables is None:
         variables = [{}]
 
-    root_table = variable_symbol_table_builder('root', variables[0])
+    root_table = variable_symbol_table_builder("root", variables[0])
 
     """:type: booleano.parser.scope.SymbolTable"""
     if constants:
-        root_table.add_subtable(
-            constants_symbol_table_builder('const', constants),
-        )
+        root_table.add_subtable(constants_symbol_table_builder("const", constants))
 
     parse_manager = EvaluableParseManager(root_table, grammar)
     return parse_manager.parse(statment)
@@ -54,4 +54,6 @@ def eval_boolean(statment, variables=None, constants=None, grammar_tokens=None):
     :return: the Truth of the statment with the given variables
     :rtype: bool
     """
-    return get_boolean_evaluator(statment, (variables or {},), constants, grammar_tokens)(variables)
+    return get_boolean_evaluator(
+        statment, (variables or {},), constants, grammar_tokens
+    )(variables)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,9 +31,19 @@ Test suite for Booleano.
 This module contains utilities shared among the whole test suite.
 
 """
-
 from __future__ import unicode_literals
+
+import logging
+from collections import OrderedDict
+from importlib import reload
+
 import six
+
+from booleano.exc import BadCallError, InvalidOperationError
+from booleano.operations import (And, BelongsTo, Equal, Function, GreaterEqual, GreaterThan, IsSubset, LessEqual,
+                                 LessThan, Not, NotEqual, Number, Or, PlaceholderFunction, PlaceholderVariable, Set,
+                                 String, Variable, Xor)
+from booleano.operations.converters import BaseConverter
 
 if six.PY2:  # pragma: nocover
     import sys
@@ -41,16 +51,6 @@ if six.PY2:  # pragma: nocover
     sys.setdefaultencoding("utf-8")
 
 
-import logging
-from collections import OrderedDict
-
-
-
-from booleano.operations.converters import BaseConverter
-from booleano.operations import (Not, And, Or, Xor, Equal, NotEqual, LessThan,
-    GreaterThan, LessEqual, GreaterEqual, BelongsTo, IsSubset, String, Number,
-    Set, Variable, Function, PlaceholderVariable, PlaceholderFunction)
-from booleano.exc import InvalidOperationError, BadCallError
 
 
 # Mock variables
@@ -420,6 +420,3 @@ class StringConverter(BaseConverter):
         namespace = ns_sep.join(namespace_parts)
         identifier = namespace + ns_sep + name
         return identifier
-
-
-

--- a/tests/operations/test_converters.py
+++ b/tests/operations/test_converters.py
@@ -31,14 +31,12 @@ Tests for the parse tree converters.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, assert_raises, raises
+from nose.tools import assert_raises, eq_, raises
 
-from booleano.operations.converters import BaseConverter
-from booleano.operations import (Not, And, Or, Xor, Equal, NotEqual, LessThan,
-    GreaterThan, LessEqual, GreaterEqual, BelongsTo, IsSubset, String, Number,
-    Set, Variable, Function, PlaceholderVariable, PlaceholderFunction)
 from booleano.exc import ConversionError
-
+from booleano.operations import (And, BelongsTo, Equal, GreaterEqual, GreaterThan, IsSubset, LessEqual, LessThan, Not,
+                                 NotEqual, Number, Or, PlaceholderFunction, PlaceholderVariable, Set, String, Xor)
+from booleano.operations.converters import BaseConverter
 from tests import AntiConverter
 
 
@@ -185,7 +183,3 @@ class TestActualConverter(object):
 
 
 ANTI_CONVERTER = AntiConverter()
-
-
-
-

--- a/tests/operations/test_operands.py
+++ b/tests/operations/test_operands.py
@@ -32,19 +32,16 @@ Tests for unbounded operands.
 from __future__ import unicode_literals
 
 import datetime
-from nose.tools import eq_, ok_, assert_false, assert_raises, raises
-import six
 
-from booleano.operations import (String, Number, Set, Variable, Function,
-                                 PlaceholderVariable, PlaceholderFunction)
-from booleano.exc import (InvalidOperationError, BadOperandError, BadCallError,
-                          BadFunctionError)
+import six
+from nose.tools import assert_false, assert_raises, eq_, ok_, raises
+
+from booleano.exc import BadCallError, BadFunctionError, BadOperandError, InvalidOperationError
+from booleano.operations import Function, Number, PlaceholderFunction, PlaceholderVariable, Set, String, Variable
 from booleano.operations.operands.constants import Constant
 from booleano.operations.operands.core import Operand
-from booleano.operations.operators import LessThan, GreaterThan
-
-from tests import (TrafficLightVar, PermissiveFunction, TrafficViolationFunc,
-                   BoolVar)
+from booleano.operations.operators import GreaterThan, LessThan
+from tests import BoolVar, PermissiveFunction, TrafficLightVar, TrafficViolationFunc
 
 
 class TestOperand(object):
@@ -93,33 +90,43 @@ class TestOperand(object):
         """Valid operations should just work."""
         class EqualityOperand(Operand):
             operations = set(["equality"])
+
             def to_python(self, value, context):
                 pass
+
             def equals(self, value, context):
                 pass
 
         class InequalityOperand(Operand):
             operations = set(["inequality"])
+
             def to_python(self, value, context):
                 pass
+
             def less_than(self, value, context):
                 pass
+
             def greater_than(self, value, context):
                 pass
 
         class BooleanOperand(Operand):
             operations = set(["boolean"])
+
             def to_python(self, value, context):
                 pass
+
             def __call__(self, value, context):
                 pass
 
         class MembershipOperand(Operand):
             operations = set(["membership"])
+
             def to_python(self, value, context):
                 pass
+
             def belongs_to(self, value, context):
                 pass
+
             def is_subset(self, value, context):
                 pass
 
@@ -140,6 +147,7 @@ class TestOperand(object):
         """Operands must define the .to_python() method."""
         class BadOperand(Operand):
             operations = set(["equality"])
+
             def equals(self, value, context):
                 pass
 
@@ -151,6 +159,7 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["boolean"])
+
             def to_python(self, context):
                 pass
 
@@ -159,6 +168,7 @@ class TestOperand(object):
         """Operands supporting equality must define the .equals() method."""
         class BadOperand(Operand):
             operations = set(["equality"])
+
             def to_python(self, context):
                 pass
 
@@ -171,6 +181,7 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["inequality"])
+
             def to_python(self, context):
                 pass
 
@@ -182,8 +193,10 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["inequality"])
+
             def to_python(self, context):
                 pass
+
             def greater_than(self, value, context):
                 pass
 
@@ -195,8 +208,10 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["inequality"])
+
             def to_python(self, context):
                 pass
+
             def less_than(self, value, context):
                 pass
 
@@ -209,6 +224,7 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["membership"])
+
             def to_python(self, context):
                 pass
 
@@ -220,8 +236,10 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["membership"])
+
             def to_python(self, context):
                 pass
+
             def is_subset(self, value, context):
                 pass
 
@@ -233,8 +251,10 @@ class TestOperand(object):
         """
         class BadOperand(Operand):
             operations = set(["membership"])
+
             def to_python(self, context):
                 pass
+
             def belongs_to(self, value, context):
                 pass
 
@@ -248,6 +268,7 @@ class TestOperand(object):
         """The operation support check setting shouldn't be inherited."""
         class ForgivenOperand(Operand):
             bypass_operation_check = True
+
         class BadOperand(ForgivenOperand):
             pass
 
@@ -287,8 +308,10 @@ class TestVariable(object):
     def test_checking_logical_support(self):
         class GreetingVariable(Variable):
             operations = set(["equality"])
+
             def to_python(self, context):
                 pass
+
             def equals(self, value, context):
                 pass
 
@@ -475,9 +498,15 @@ class TestFunction(object):
     def test_checking_logical_support(self):
         class NoBoolFunction(Function):
             operations = set(["equality"])
-            def equals(self, node): pass
-            def to_python(self): pass
-            def check_arguments(self): pass
+
+            def equals(self, node):
+                pass
+
+            def to_python(self):
+                pass
+
+            def check_arguments(self):
+                pass
 
         func1 = PermissiveFunction(String("foo"))
         func2 = NoBoolFunction()
@@ -495,7 +524,9 @@ class TestFunction(object):
             bypass_operation_check = True
             required_arguments = ("abc", )
             optional_arguments = {"xyz": String("123")}
-            def check_arguments(self): pass
+
+            def check_arguments(self):
+                pass
 
         func1 = FooFunction(String("whatever"))
         func2 = FooFunction(String("whatever"))
@@ -1278,14 +1309,11 @@ class TestPlaceholderFunction(object):
     def test_representation_with_namespace(self):
         # With Unicode:
         func = PlaceholderFunction(u"aquí", ["a", "d"], Number(1), String("hi"))
-        eq_('<Placeholder function call "aquí"(<Number 1.0>, <String "hi">) ' \
+        eq_('<Placeholder function call "aquí"(<Number 1.0>, <String "hi">) '
             'at namespace="a:d">',
             repr(func))
         # With ASCII:
         func = PlaceholderFunction("here", ["a", "d"], Number(1), String("hi"))
-        eq_(u'<Placeholder function call "here"(<Number 1.0>, <String "hi">) ' \
+        eq_(u'<Placeholder function call "here"(<Number 1.0>, <String "hi">) '
             'at namespace="a:d">',
             repr(func))
-
-
-

--- a/tests/operations/test_operators.py
+++ b/tests/operations/test_operators.py
@@ -31,16 +31,14 @@ Tests for the operators.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, ok_, assert_false, assert_raises, raises
-import six
-from booleano.operations import (Not, And, Or, Xor, Equal, NotEqual, LessThan,
-    GreaterThan, LessEqual, GreaterEqual, BelongsTo, IsSubset)
-from booleano.operations.operators import Operator
-from booleano.operations.operands import String, Number, Set, Variable
-from booleano.exc import InvalidOperationError
+from nose.tools import assert_false, assert_raises, eq_, ok_
 
-from tests import (TrafficLightVar, PedestriansCrossingRoad,
-                   DriversAwaitingGreenLightVar, BoolVar)
+from booleano.exc import InvalidOperationError
+from booleano.operations import (And, BelongsTo, Equal, GreaterEqual, GreaterThan, IsSubset, LessEqual, LessThan, Not,
+                                 NotEqual, Or, Xor)
+from booleano.operations.operands import Number, Set, String, Variable
+from booleano.operations.operators import Operator
+from tests import BoolVar, DriversAwaitingGreenLightVar, PedestriansCrossingRoad, TrafficLightVar
 
 
 class TestOperator(object):
@@ -91,8 +89,8 @@ class TestNot(object):
         traffic_light = TrafficLightVar()
         operation = Not(traffic_light)
         # Evaluation:
-        ok_(operation( dict(traffic_light="") ))
-        assert_false(operation( dict(traffic_light="green") ))
+        ok_(operation(dict(traffic_light="")))
+        assert_false(operation(dict(traffic_light="green")))
 
     def test_equivalent(self):
         """
@@ -151,15 +149,15 @@ class TestAnd(object):
 
     def test_with_both_results_as_true(self):
         operation = And(BoolVar(), TrafficLightVar())
-        ok_(operation( dict(bool=True, traffic_light="red") ))
+        ok_(operation(dict(bool=True, traffic_light="red")))
 
     def test_with_both_results_as_false(self):
         operation = And(BoolVar(), TrafficLightVar())
-        assert_false(operation( dict(bool=False, traffic_light="") ))
+        assert_false(operation(dict(bool=False, traffic_light="")))
 
     def test_with_mixed_results(self):
         operation = And(BoolVar(), TrafficLightVar())
-        assert_false(operation( dict(bool=False, traffic_light="red") ))
+        assert_false(operation(dict(bool=False, traffic_light="red")))
 
     def test_evaluation_order(self):
         """
@@ -229,15 +227,15 @@ class TestOr(object):
 
     def test_with_both_results_as_true(self):
         operation = Or(BoolVar(), TrafficLightVar())
-        ok_(operation( dict(bool=True, traffic_light="red") ))
+        ok_(operation(dict(bool=True, traffic_light="red")))
 
     def test_with_both_results_as_false(self):
         operation = Or(BoolVar(), TrafficLightVar())
-        assert_false(operation( dict(bool=False, traffic_light="") ))
+        assert_false(operation(dict(bool=False, traffic_light="")))
 
     def test_with_mixed_results(self):
         operation = Or(BoolVar(), TrafficLightVar())
-        ok_(operation( dict(bool=False, traffic_light="red") ))
+        ok_(operation(dict(bool=False, traffic_light="red")))
 
     def test_evaluation_order(self):
         """
@@ -311,15 +309,15 @@ class TestXor(object):
 
     def test_with_both_results_as_true(self):
         operation = Xor(BoolVar(), TrafficLightVar())
-        assert_false(operation( dict(bool=True, traffic_light="red") ))
+        assert_false(operation(dict(bool=True, traffic_light="red")))
 
     def test_with_both_results_as_false(self):
         operation = Xor(BoolVar(), TrafficLightVar())
-        assert_false(operation( dict(bool=False, traffic_light="") ))
+        assert_false(operation(dict(bool=False, traffic_light="")))
 
     def test_with_mixed_results(self):
         operation = Xor(BoolVar(), TrafficLightVar())
-        ok_(operation( dict(bool=False, traffic_light="red") ))
+        ok_(operation(dict(bool=False, traffic_light="red")))
 
     def test_equivalent(self):
         """
@@ -398,18 +396,6 @@ class TestNonConnectiveBinaryOperators(object):
         eq_(l_op, operation.master_operand)
         eq_(r_op, operation.slave_operand)
 
-    def test_constructor_with_variable_before_constant(self):
-        """
-        The order must change when the first argument is a constant and the
-        other is a variable.
-
-        """
-        l_op = String("hello")
-        r_op = BoolVar()
-        operation = Equal(l_op, r_op)
-        eq_(r_op, operation.master_operand)
-        eq_(l_op, operation.slave_operand)
-
     def test_equivalent(self):
         """
         Two binary operators are equivalent if they have the same operands.
@@ -473,7 +459,7 @@ class TestEqual(object):
         operation = Equal(
             PedestriansCrossingRoad(),
             Set(String("gustavo"), String("carla"))
-        )
+    )
 
         # The same people:
         context = {'pedestrians_crossroad': ("gustavo", "carla")}
@@ -516,7 +502,7 @@ class TestNotEqual(object):
         operation = NotEqual(
             PedestriansCrossingRoad(),
             Set(String("gustavo"), String("carla"))
-        )
+    )
 
         # Other people:
         context = {'pedestrians_crossroad': ("liliana", "carlos")}
@@ -599,7 +585,7 @@ class TestLessThan(object):
 
         # |{"carla"}| < 2   <=>   1 < 2
         context = {
-            'pedestrians_crossroad': ("carla", ),
+            'pedestrians_crossroad': ("carla",),
             'num': 2,
         }
         ok_(operation(context))
@@ -617,7 +603,7 @@ class TestLessThan(object):
         operation = LessThan(l_op, r_op)
 
         # |{"carla"}| < 2   <=>   1 < 2
-        context = {'pedestrians_crossroad': ("carla", )}
+        context = {'pedestrians_crossroad': ("carla",)}
         ok_(operation(context))
 
         # |{"carla", "carlos", "liliana"}| < 2   <=>   3 < 2
@@ -681,7 +667,7 @@ class TestGreaterThan(object):
         ok_(operation(context))
 
         # |{"carla"}| > 2   <=>   1 > 2
-        context = {'pedestrians_crossroad': ("carla", )}
+        context = {'pedestrians_crossroad': ("carla",)}
         assert_false(operation(context))
 
 
@@ -707,7 +693,7 @@ class TestLessEqual(object):
 
         # |{"carla"}| < 2   <=>   1 < 2
         context = {
-            'pedestrians_crossroad': ("carla", ),
+            'pedestrians_crossroad': ("carla",),
             'num': 2,
         }
         ok_(operation(context))
@@ -725,7 +711,7 @@ class TestLessEqual(object):
         operation = LessEqual(l_op, r_op)
 
         # |{"carla"}| < 2   <=>   1 < 2
-        context = {'pedestrians_crossroad': ("carla", )}
+        context = {'pedestrians_crossroad': ("carla",)}
         ok_(operation(context))
 
         # |{"carla", "carlos", "liliana"}| < 2   <=>   1 < 2
@@ -777,7 +763,7 @@ class TestGreaterEqual(object):
         ok_(operation(context))
 
         # |{"carla"}| > 2   <=>   1 > 2
-        context = {'pedestrians_crossroad': ("carla", )}
+        context = {'pedestrians_crossroad': ("carla",)}
         assert_false(operation(context))
 
 
@@ -850,7 +836,7 @@ class TestIsSubset(object):
 
         # {"carla"} ⊂ {"carla", "andreina"}
         context = {
-            'drivers_trafficlight': ("carla", ),
+            'drivers_trafficlight': ("carla",),
             'pedestrians_crossroad': ("andreina", "carla")
         }
         ok_(operation(context))
@@ -886,6 +872,3 @@ class NumVar(Variable):
 
     def greater_than(self, value, context):
         return context['num'] > value
-
-
-

--- a/tests/operations/test_variables.py
+++ b/tests/operations/test_variables.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import datetime
 
 import six
-from nose.tools import ok_, assert_raises, assert_equal
+from nose.tools import assert_equal, assert_raises, ok_
 from nose.tools.trivial import eq_
 
-from booleano.operations.operands.constants import Number, String
-from booleano.operations.variables import NumberVariable, BooleanVariable, StringVariable, DateVariable, \
-    DateTimeVariable, SetVariable, NativeVariable, DurationVariable
-from booleano.parser.symbol_table_builder import SymbolTableBuilder
-from booleano.parser import SymbolTable, Bind, Grammar
+from booleano.operations.operands.constants import String
+from booleano.operations.variables import (BooleanVariable, DateTimeVariable, DateVariable, DurationVariable,
+                                           NativeVariable, NumberVariable, SetVariable, StringVariable)
+from booleano.parser import Bind, Grammar, SymbolTable
 from booleano.parser.core import EvaluableParseManager
+from booleano.parser.symbol_table_builder import SymbolTableBuilder
 
 
 class TestNativeVariableEvaluableParseManager(object):
@@ -34,43 +35,36 @@ class TestNativeVariableEvaluableParseManager(object):
             Bind("myset", SetVariable("myset")),
             Bind("myintbis", NumberVariable("myint")),
         ),
+        SymbolTable("sub", (Bind("myint", NumberVariable("sub.myint")),)),
         SymbolTable(
-            "sub",
-            (
-                Bind("myint", NumberVariable("sub.myint")),
-            ),
+            "const", (Bind("hello", String("hello")), Bind("li", String("li")))
         ),
-        SymbolTable(
-            "const",
-            (
-                Bind("hello", String("hello")),
-                Bind("li", String("li")),
-            )
-        )
     )
 
-    mgr = EvaluableParseManager(symbol_table, Grammar(belongs_to='in', is_subset='is subset of'))
+    mgr = EvaluableParseManager(
+        symbol_table, Grammar(belongs_to="in", is_subset="is subset of")
+    )
 
     def test_variable_values_myint(self):
-        ok_(self.mgr.parse('myint > 0')({'myint': 1}))
-        ok_(not self.mgr.parse('myint > 0')({'myint': 0}))
-        ok_(self.mgr.parse('myint == 1')({'myint': 1}))
-        ok_(not self.mgr.parse('myint == 1')({'myint': 0}))
-        ok_(self.mgr.parse('myint < 1')({'myint': 0}))
-        ok_(not self.mgr.parse('myint < 0')({'myint': 2}))
+        ok_(self.mgr.parse("myint > 0")({"myint": 1}))
+        ok_(not self.mgr.parse("myint > 0")({"myint": 0}))
+        ok_(self.mgr.parse("myint == 1")({"myint": 1}))
+        ok_(not self.mgr.parse("myint == 1")({"myint": 0}))
+        ok_(self.mgr.parse("myint < 1")({"myint": 0}))
+        ok_(not self.mgr.parse("myint < 0")({"myint": 2}))
 
     def test_variable_values_mybool(self):
-        ok_(self.mgr.parse('mybool')({'mybool': True}))
-        ok_(not self.mgr.parse('mybool')({'mybool': False}))
-        ok_(self.mgr.parse('mybool > 0')({'mybool': True}))
-        ok_(not self.mgr.parse('mybool > 0')({'mybool': False}))
-        ok_(self.mgr.parse('mybool == 1')({'mybool': True}))
-        ok_(not self.mgr.parse('mybool == 1')({'mybool': False}))
-        ok_(self.mgr.parse('mybool < 1')({'mybool': False}))
-        ok_(not self.mgr.parse('mybool < 0')({'mybool': True}))
+        ok_(self.mgr.parse("mybool")({"mybool": True}))
+        ok_(not self.mgr.parse("mybool")({"mybool": False}))
+        ok_(self.mgr.parse("mybool > 0")({"mybool": True}))
+        ok_(not self.mgr.parse("mybool > 0")({"mybool": False}))
+        ok_(self.mgr.parse("mybool == 1")({"mybool": True}))
+        ok_(not self.mgr.parse("mybool == 1")({"mybool": False}))
+        ok_(self.mgr.parse("mybool < 1")({"mybool": False}))
+        ok_(not self.mgr.parse("mybool < 0")({"mybool": True}))
 
     def test_variable_values_mystring(self):
-        mystring = {'mystring': "hello"}
+        mystring = {"mystring": "hello"}
         # equiality
         ok_(self.mgr.parse('mystring == "hello"')(mystring))
         ok_(not self.mgr.parse('mystring != "hello"')(mystring))
@@ -89,10 +83,10 @@ class TestNativeVariableEvaluableParseManager(object):
         ok_(self.mgr.parse('"hello" >= mystring')(mystring))
         ok_(self.mgr.parse('"hello" >= mystring')(mystring))
         # bool
-        ok_(self.mgr.parse('mystring')(mystring))
-        ok_(not self.mgr.parse('~ mystring')(mystring))
-        ok_(not self.mgr.parse('mystring')({'mystring': ''}))
-        ok_(self.mgr.parse('~ mystring')({'mystring': ''}))
+        ok_(self.mgr.parse("mystring")(mystring))
+        ok_(not self.mgr.parse("~ mystring")(mystring))
+        ok_(not self.mgr.parse("mystring")({"mystring": ""}))
+        ok_(self.mgr.parse("~ mystring")({"mystring": ""}))
         # membership
         ok_(self.mgr.parse('mystring is subset of "zhelloy"')(mystring))
         ok_(not self.mgr.parse('mystring is subset of "zhellai"')(mystring))
@@ -109,20 +103,22 @@ class TestNativeVariableEvaluableParseManager(object):
         ok_(not self.mgr.parse('"li" is subset of mystring')(mystring))
         ok_(not self.mgr.parse(' "hello" is subset of mystring')(mystring))
         # test to string
-        ok_(not self.mgr.parse('const:hello is subset of mystring')(mystring))
-        ok_(not self.mgr.parse('const:li in mystring')(mystring))
+        ok_(not self.mgr.parse("const:hello is subset of mystring")(mystring))
+        ok_(not self.mgr.parse("const:li in mystring")(mystring))
 
     def test_variable_str(self):
-        eq_("%s" % NativeVariable('coucou'), 'Scop variable for coucou [NativeVariable]')
-        eq_("%s" % BooleanVariable('name'), 'Scop variable for name [BooleanVariable]')
-        eq_("%s" % NumberVariable('age'), 'Scop variable for age [NumberVariable]')
+        eq_(
+            "%s" % NativeVariable("coucou"), "Scop variable for coucou [NativeVariable]"
+        )
+        eq_("%s" % BooleanVariable("name"), "Scop variable for name [BooleanVariable]")
+        eq_("%s" % NumberVariable("age"), "Scop variable for age [NumberVariable]")
 
     def test_variable_values_date(self):
         mydate = {
-            'mydate': datetime.date(2017, 1, 15),
-            'mydate2': datetime.date(2017, 1, 17),
+            "mydate": datetime.date(2017, 1, 15),
+            "mydate2": datetime.date(2017, 1, 17),
         }
-        ok_(self.mgr.parse('mydate')(mydate))
+        ok_(self.mgr.parse("mydate")(mydate))
 
         ok_(self.mgr.parse('mydate < "2017-01-18"')(mydate))
         ok_(self.mgr.parse('mydate < "18-01-2017"')(mydate))
@@ -130,18 +126,18 @@ class TestNativeVariableEvaluableParseManager(object):
         ok_(self.mgr.parse('mydate > "12-01-2017"')(mydate))
 
         ok_(self.mgr.parse('mydate == "15-01-2017"')(mydate))
-        ok_(not self.mgr.parse('mydate == 1')(mydate))
+        ok_(not self.mgr.parse("mydate == 1")(mydate))
         ok_(not self.mgr.parse('mydate == "13-01-2017"')(mydate))
-        ok_(self.mgr.parse('mydate < mydate2')(mydate))
-        ok_(not self.mgr.parse('mydate > mydate2')(mydate))
-        ok_(not self.mgr.parse('mydate == mydate2')(mydate))
+        ok_(self.mgr.parse("mydate < mydate2")(mydate))
+        ok_(not self.mgr.parse("mydate > mydate2")(mydate))
+        ok_(not self.mgr.parse("mydate == mydate2")(mydate))
 
     def test_variable_values_datetime(self):
         mydatetime = {
-            'mydatetime': datetime.datetime(2017, 1, 15, 12, 25),
-            'mydatetime2': datetime.datetime(2017, 1, 17, 12, 23),
+            "mydatetime": datetime.datetime(2017, 1, 15, 12, 25),
+            "mydatetime2": datetime.datetime(2017, 1, 17, 12, 23),
         }
-        ok_(self.mgr.parse('mydatetime')(mydatetime))
+        ok_(self.mgr.parse("mydatetime")(mydatetime))
 
         ok_(self.mgr.parse('mydatetime < "2017-01-15 12:25:02"')(mydatetime))
         ok_(self.mgr.parse('mydatetime > "2017-01-15 12:24:52"')(mydatetime))
@@ -152,16 +148,14 @@ class TestNativeVariableEvaluableParseManager(object):
         ok_(self.mgr.parse('mydatetime > "12-01-2017 12:25:02"')(mydatetime))
 
         ok_(self.mgr.parse('mydatetime == "15-01-2017 12:25:00"')(mydatetime))
-        ok_(not self.mgr.parse('mydatetime == 1')(mydatetime))
+        ok_(not self.mgr.parse("mydatetime == 1")(mydatetime))
         ok_(not self.mgr.parse('mydatetime == "13-01-2017 12:25:02"')(mydatetime))
-        ok_(self.mgr.parse('mydatetime < mydatetime2')(mydatetime))
-        ok_(not self.mgr.parse('mydatetime > mydatetime2')(mydatetime))
-        ok_(not self.mgr.parse('mydatetime == mydatetime2')(mydatetime))
+        ok_(self.mgr.parse("mydatetime < mydatetime2")(mydatetime))
+        ok_(not self.mgr.parse("mydatetime > mydatetime2")(mydatetime))
+        ok_(not self.mgr.parse("mydatetime == mydatetime2")(mydatetime))
 
     def test_variable_values_set(self):
-        myset = {
-            "myset": {1, 2, 3},
-        }
+        myset = {"myset": {1, 2, 3}}
         ok_(self.mgr.parse("1 is subset of myset ")(myset))
         ok_(self.mgr.parse("{1, 2} is subset of myset ")(myset))
         ok_(not self.mgr.parse("{1, 2, 3} is subset of myset ")(myset))
@@ -170,24 +164,21 @@ class TestNativeVariableEvaluableParseManager(object):
         ok_(self.mgr.parse("{1, 2, 3} in myset ")(myset))
 
     def test_variable_values_namespaced(self):
-        myints = {
-            "myint": 1,
-            "sub.myint": 4
-        }
-        ok_(self.mgr.parse('sub:myint > 3')(myints))
-        ok_(self.mgr.parse('sub:myint < 5')(myints))
-        ok_(self.mgr.parse('sub:myint == 4')(myints))
-        ok_(self.mgr.parse('sub:myint > myint')(myints))
-        ok_(not self.mgr.parse('sub:myint < myint')(myints))
-        ok_(not self.mgr.parse('sub:myint == myint')(myints))
+        myints = {"myint": 1, "sub.myint": 4}
+        ok_(self.mgr.parse("sub:myint > 3")(myints))
+        ok_(self.mgr.parse("sub:myint < 5")(myints))
+        ok_(self.mgr.parse("sub:myint == 4")(myints))
+        ok_(self.mgr.parse("sub:myint > myint")(myints))
+        ok_(not self.mgr.parse("sub:myint < myint")(myints))
+        ok_(not self.mgr.parse("sub:myint == myint")(myints))
 
     def test_format_date(self):
-        dt = DateVariable("mydate", '%d %m %y')
+        dt = DateVariable("mydate", "%d %m %y")
         assert_raises(ValueError, dt._from_native_string, "2001-03-04")
-        eq_(dt._from_native_string( "04 03 01"), datetime.date(2001, 3, 4))
+        eq_(dt._from_native_string("04 03 01"), datetime.date(2001, 3, 4))
 
     def test_multi_formats(self):
-        dt = DateVariable("mydate", ['%d %m %Y', '%Y %m %d'])
+        dt = DateVariable("mydate", ["%d %m %Y", "%Y %m %d"])
         assert_raises(ValueError, dt._from_native_string, "2001-03-04")
         assert_raises(ValueError, dt._from_native_string, "04-03-2001")
         eq_(dt._from_native_string("04 03 2001"), datetime.date(2001, 3, 4))
@@ -195,36 +186,53 @@ class TestNativeVariableEvaluableParseManager(object):
 
 
 class TestDurationVariable(object):
-
     def test_default_durations_formats(self):
-        d = DurationVariable('ctx_name')
-        eq_(d._from_native_string('1d'), datetime.timedelta(days=1))
-        eq_(d._from_native_string('1d2s'), datetime.timedelta(days=1, seconds=2))
-        eq_(d._from_native_string('1d4m2s'), datetime.timedelta(days=1, seconds=2, minutes=4))
-        eq_(d._from_native_string('1d5h4m2s'), datetime.timedelta(days=1, seconds=2, minutes=4, hours=5))
-        eq_(d._from_native_string('1 days 5 hours 4 minutes 2 seconds'), datetime.timedelta(days=1, seconds=2, minutes=4, hours=5))
-        eq_(d._from_native_string('1days 5hours 4minutes 2seconds'), datetime.timedelta(days=1, seconds=2, minutes=4, hours=5))
-        eq_(d._from_native_string('1 days 2 seconds'), datetime.timedelta(days=1, seconds=2))
+        d = DurationVariable("ctx_name")
+        eq_(d._from_native_string("1d"), datetime.timedelta(days=1))
+        eq_(d._from_native_string("1d2s"), datetime.timedelta(days=1, seconds=2))
+        eq_(
+            d._from_native_string("1d4m2s"),
+            datetime.timedelta(days=1, seconds=2, minutes=4),
+        )
+        eq_(
+            d._from_native_string("1d5h4m2s"),
+            datetime.timedelta(days=1, seconds=2, minutes=4, hours=5),
+        )
+        eq_(
+            d._from_native_string("1 days 5 hours 4 minutes 2 seconds"),
+            datetime.timedelta(days=1, seconds=2, minutes=4, hours=5),
+        )
+        eq_(
+            d._from_native_string("1days 5hours 4minutes 2seconds"),
+            datetime.timedelta(days=1, seconds=2, minutes=4, hours=5),
+        )
+        eq_(
+            d._from_native_string("1 days 2 seconds"),
+            datetime.timedelta(days=1, seconds=2),
+        )
 
     def test_custom_duration_formats(self):
 
-        dv = DurationVariable('ctx_name', r'^((?P<days>\d+?) ?j(ours?)?)?')
+        dv = DurationVariable("ctx_name", r"^((?P<days>\d+?) ?j(ours?)?)?")
         assert_raises(ValueError, dv._from_native_string, "1d")
-        eq_(dv._from_native_string('1j'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1jour'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1jours'), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1j"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1jour"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1jours"), datetime.timedelta(days=1))
 
     def test_multi_custom_duration_format(self):
-        dv = DurationVariable('ctx_name', [r'^((?P<days>\d+?) ?j(ours?)?)?', r'^((?P<days>\d+?) ?d(ías)?)?'])
+        dv = DurationVariable(
+            "ctx_name",
+            [r"^((?P<days>\d+?) ?j(ours?)?)?", r"^((?P<days>\d+?) ?d(ías)?)?"],
+        )
         assert_raises(ValueError, dv._from_native_string, "1s")
-        eq_(dv._from_native_string('1j'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1jour'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1jours'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1d'), datetime.timedelta(days=1))
-        eq_(dv._from_native_string('1días'), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1j"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1jour"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1jours"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1d"), datetime.timedelta(days=1))
+        eq_(dv._from_native_string("1días"), datetime.timedelta(days=1))
 
     def test_bad_formated_date(self):
-        d = DurationVariable('ctx_name')
+        d = DurationVariable("ctx_name")
         assert_raises(ValueError, d._from_native_string, "")
         assert_raises(ValueError, d._from_native_string, "1j")  # bad j unit
         assert_raises(ValueError, d._from_native_string, "10s10d")  # bad order
@@ -232,33 +240,32 @@ class TestDurationVariable(object):
 
 
 class TestVariableLazyResolve(object):
-
     def test_raw_val(self):
-        c = NumberVariable('n')
-        eq_(c.to_python({'n': 1}), 1)
+        c = NumberVariable("n")
+        eq_(c.to_python({"n": 1}), 1)
 
     def test_lazy_val(self):
         calls = []
 
         def lazy(context):
             calls.append(1)
-            return context['n']
+            return context["n"]
 
         eq_(calls, [])
         c = NumberVariable(lazy)
         eq_(calls, [])
-        eq_(c.to_python({'n': 1}), 1)
+        eq_(c.to_python({"n": 1}), 1)
         eq_(calls, [1])
-        eq_(c.to_python({'n': 1}), 1)
+        eq_(c.to_python({"n": 1}), 1)
         eq_(calls, [1, 1])
 
 
 class TestVariableSymbolTableBuilder(object):
-    FakeVariable = type(str('FakeVariable'), (NativeVariable,), {})
-    FakeVariableSub = type(str('FakeVariable'), (FakeVariable,), {})
+    FakeVariable = type(str("FakeVariable"), (NativeVariable,), {})
+    FakeVariableSub = type(str("FakeVariable"), (FakeVariable,), {})
 
-    MyString = type(str('MyString'), (str,), {})
-    MyStringVariable = type(str('MyStringVariable'), (NativeVariable,), {})
+    MyString = type(str("MyString"), (str,), {})
+    MyStringVariable = type(str("MyStringVariable"), (NativeVariable,), {})
 
     def test_registering(self):
         vb = SymbolTableBuilder()
@@ -297,27 +304,29 @@ class TestVariableSymbolTableBuilder(object):
         vb.register(six.text_type, self.FakeVariable)
         vb.register(int, self.FakeVariableSub)
         st = vb("root", {"name": "katara", "age": 15})
-        assert_equal(st, SymbolTable('root', (
-            Bind("name", self.FakeVariable),
-            Bind("age", self.FakeVariableSub),
-        )))
+        assert_equal(
+            st,
+            SymbolTable(
+                "root",
+                (Bind("name", self.FakeVariable), Bind("age", self.FakeVariableSub)),
+            ),
+        )
 
     def test_creation_table_with_type(self):
         vb = SymbolTableBuilder()
         vb.register(six.text_type, self.FakeVariable)
         vb.register(int, self.FakeVariableSub)
         st = vb("root", {"name": six.text_type, "age": 15})
-        assert_equal(st, SymbolTable('root', (
-            Bind("name", self.FakeVariable),
-            Bind("age", self.FakeVariableSub),
-        )))
+        assert_equal(
+            st,
+            SymbolTable(
+                "root",
+                (Bind("name", self.FakeVariable), Bind("age", self.FakeVariableSub)),
+            ),
+        )
 
     def test_creation_table_unknown_type(self):
         vb = SymbolTableBuilder()
         vb.register(six.text_type, self.FakeVariable)
         vb.register(int, self.FakeVariableSub)
-        assert_raises(Exception,
-                      vb, "root", {"name": "katara", "age": 15.}
-                      )
-
-
+        assert_raises(Exception, vb, "root", {"name": "katara", "age": 15.0})

--- a/tests/parsing/test_grammar.py
+++ b/tests/parsing/test_grammar.py
@@ -31,10 +31,10 @@ Test suite for the grammar configurations.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import assert_raises, eq_
 
-from booleano.parser import Grammar
 from booleano.exc import GrammarError
+from booleano.parser import Grammar
 
 
 class TestDefaultGrammar(object):

--- a/tests/parsing/test_parsers.py
+++ b/tests/parsing/test_parsers.py
@@ -31,22 +31,18 @@ Test suite for the built-in parser implementation.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, assert_raises
 import six
+from nose.tools import assert_raises, eq_
 
+from booleano.exc import BadExpressionError, ScopeError
+from booleano.operations import (And, BelongsTo, Equal, GreaterEqual, GreaterThan, IsSubset, LessEqual, LessThan, Not,
+                                 NotEqual, Number, Or, PlaceholderFunction, PlaceholderVariable, Set, String, Xor)
 from booleano.parser.grammar import Grammar
-from booleano.parser.parsers import EvaluableParser, ConvertibleParser
+from booleano.parser.parsers import ConvertibleParser, EvaluableParser, Parser
 from booleano.parser.scope import Namespace
-from booleano.parser.parsers import Parser
-from booleano.operations import (Not, And, Or, Xor, Equal, NotEqual, LessThan,
-    GreaterThan, LessEqual, GreaterEqual, BelongsTo, IsSubset, String, Number,
-    Set, PlaceholderVariable, PlaceholderFunction)
 from booleano.parser.testutils import BaseGrammarTest
-from booleano.exc import ScopeError, BadExpressionError
-
-from tests import (StringConverter, BoolVar, TrafficLightVar,
-                   PedestriansCrossingRoad, DriversAwaitingGreenLightVar,
-                   PermissiveFunction, TrafficViolationFunc)
+from tests import (BoolVar, DriversAwaitingGreenLightVar, PedestriansCrossingRoad, PermissiveFunction, StringConverter,
+                   TrafficLightVar, TrafficViolationFunc)
 
 
 class TestDefaultGrammar(BaseGrammarTest):
@@ -477,16 +473,6 @@ class TestDefaultGrammar(BaseGrammarTest):
                     )
                 )
             ),
-        'W == 0   |   (X != 1   ^   (Y > 2   &   Z < 3))': Or(
-            Equal(PlaceholderVariable("W"), Number(0)),
-            Xor(
-                NotEqual(PlaceholderVariable("X"), Number(1)),
-                And(
-                    GreaterThan(PlaceholderVariable("Y"), Number(2)),
-                    LessThan(PlaceholderVariable("Z"), Number(3))
-                    )
-                )
-            ),
         'W == 0   |   ((X != 1   ^   Y > 2)   &   Z < 3)': Or(
             Equal(PlaceholderVariable("W"), Number(0)),
             And(
@@ -572,14 +558,14 @@ class TestDefaultGrammar(BaseGrammarTest):
             Set(String("orange"), String("apple"))
             ),
         u'{"españa", {"caracas", {"las chimeneas", "el trigal"}}, "france"}': \
-            Set(
-                String(u"españa"),
-                String("france"),
                 Set(
-                    String("caracas"),
-                    Set(String("el trigal"), String("las chimeneas"))
+                    String(u"españa"),
+                    String("france"),
+                    Set(
+                        String("caracas"),
+                        Set(String("el trigal"), String("las chimeneas"))
+                    ),
                 ),
-            ),
         '{var1, var2}': Set(PlaceholderVariable("var1"),
                             PlaceholderVariable("var2")),
         '{var, "string"}': Set(PlaceholderVariable("var"), String("string")),
@@ -909,6 +895,3 @@ class TestEvaluableParser(object):
             eq_('"bool" is not a function', six.text_type(exc))
         else:
             assert 0, '"bool" is a variable, not a function!'
-
-    #
-

--- a/tests/parsing/test_scope.py
+++ b/tests/parsing/test_scope.py
@@ -31,14 +31,13 @@ Scope handling tests.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, ok_, assert_false, assert_raises, raises
 import six
-from booleano.parser.scope import Bind, SymbolTable, Namespace, _Identifier
-from booleano.operations import String, Number
-from booleano.exc import ScopeError
+from nose.tools import assert_raises, eq_, ok_
 
-from tests import (TrafficLightVar, PermissiveFunction, TrafficViolationFunc,
-                   BoolVar, LoggingHandlerFixture)
+from booleano.exc import ScopeError
+from booleano.operations import Number, String
+from booleano.parser.scope import Bind, Namespace, SymbolTable, _Identifier
+from tests import BoolVar, LoggingHandlerFixture, TrafficLightVar, TrafficViolationFunc
 
 
 class TestIdentifiers(object):
@@ -157,7 +156,7 @@ class TestBind(object):
         ok_(bind7 == bind9)
         ok_(bind9 == bind7)
 
-        ok_(bind1 != None)
+        ok_(bind1 is not None)
         ok_(bind1 != SymbolTable("name1", []))
 
         ok_(bind1 != bind2)
@@ -638,16 +637,16 @@ class TestSymbolTable(object):
         bool_var = BoolVar()
         traffic = TrafficLightVar()
         st = SymbolTable("global",
-            (
-                Bind("bool", BoolVar(), es="booleano", fr=u"booléen"),
-                Bind("traffic", TrafficLightVar(), es=u"tráfico")
+                        (
+                            Bind("bool", BoolVar(), es="booleano", fr=u"booléen"),
+                            Bind("traffic", TrafficLightVar(), es=u"tráfico")
             ),
             SymbolTable("foo",
-                (
-                    Bind("bar", bool_var, es="fulano"),
-                    Bind("baz", traffic, es="mengano", fr="bonjour"),
-                ),
-            ),
+                        (
+                            Bind("bar", bool_var, es="fulano"),
+                            Bind("baz", traffic, es="mengano", fr="bonjour"),
+                        ),
+                        ),
         )
 
         # Checking the namespace:
@@ -710,10 +709,7 @@ class TestSymbolTable(object):
         ok_(st10 == st5)
         ok_(st11 == st12)
         ok_(st12 == st11)
-
-        ok_(st1 != None)
-        ok_(st1 != Bind("foo", String("cachapa")))
-
+        ok_(st1 is not None)
         ok_(st1 != st3)
         ok_(st1 != st4)
         ok_(st1 != st6)
@@ -921,4 +917,3 @@ class TestNamespaces(object):
         }
         st = Namespace(global_objects,)
         assert_raises(ScopeError, st.get_object, "bool")
-

--- a/tests/parsing/test_trees.py
+++ b/tests/parsing/test_trees.py
@@ -31,14 +31,13 @@ Tests for the parse trees.
 """
 from __future__ import unicode_literals
 
-from nose.tools import eq_, ok_, assert_false, assert_raises, raises
 import six
-from booleano.parser.trees import EvaluableParseTree, ConvertibleParseTree
-from booleano.operations import And, String, PlaceholderVariable
-from booleano.exc import InvalidOperationError
+from nose.tools import assert_false, assert_raises, eq_, ok_
 
-from tests import (TrafficLightVar, PedestriansCrossingRoad, BoolVar,
-                   DriversAwaitingGreenLightVar, AntiConverter)
+from booleano.exc import InvalidOperationError
+from booleano.operations import And, PlaceholderVariable, String
+from booleano.parser.trees import ConvertibleParseTree, EvaluableParseTree
+from tests import AntiConverter, BoolVar, DriversAwaitingGreenLightVar, PedestriansCrossingRoad, TrafficLightVar
 
 
 class TestEvaluableTrees(object):
@@ -49,31 +48,33 @@ class TestEvaluableTrees(object):
         operand = TrafficLightVar()
         tree = EvaluableParseTree(operand)
         # True
-        context = {'traffic_light': "red"}
+        context = {"traffic_light": "red"}
         ok_(tree(context))
         # False
-        context = {'traffic_light': None}
+        context = {"traffic_light": None}
         assert_false(tree(context))
 
     def test_non_boolean_operands(self):
         """Only operands that support logical values are supported."""
+
         class FakeString(String):
             operations = {"equality"}
+
         operand = FakeString("I'm a string")
         assert_raises(InvalidOperationError, EvaluableParseTree, operand)
 
     def test_operation(self):
         """Operations are valid evaluable parse trees."""
-        operation = And(PedestriansCrossingRoad(),
-                        DriversAwaitingGreenLightVar())
+        operation = And(PedestriansCrossingRoad(), DriversAwaitingGreenLightVar())
         tree = EvaluableParseTree(operation)
         # True
-        context = {'pedestrians_crossroad': ("gustavo", "carla"),
-                   'drivers_trafficlight': ("andreina", "juan")}
+        context = {
+            "pedestrians_crossroad": ("gustavo", "carla"),
+            "drivers_trafficlight": ("andreina", "juan"),
+        }
         ok_(tree(context))
         # False
-        context = {'pedestrians_crossroad': (),
-                   'drivers_traffic_light': ()}
+        context = {"pedestrians_crossroad": (), "drivers_traffic_light": ()}
         assert_false(tree(context))
 
     def test_equivalence(self):
@@ -85,7 +86,7 @@ class TestEvaluableTrees(object):
         ok_(tree1 == tree2)
         ok_(tree2 == tree1)
 
-        ok_(tree1 != None)
+        ok_(tree1 is not None)
         ok_(tree1 != tree3)
         ok_(tree1 != tree4)
         ok_(tree2 != tree3)
@@ -129,7 +130,7 @@ class TestConvertibleTrees(object):
         ok_(tree1 == tree2)
         ok_(tree2 == tree1)
 
-        ok_(tree1 != None)
+        ok_(tree1 is not None)
         ok_(tree1 != tree3)
         ok_(tree1 != tree4)
         ok_(tree2 != tree3)
@@ -149,7 +150,5 @@ class TestConvertibleTrees(object):
 
     def test_representation(self):
         tree = ConvertibleParseTree(BoolVar())
-        expected = "<Parse tree (convertible) " \
-                   "<Anonymous variable [BoolVar]>>"
+        expected = "<Parse tree (convertible) " "<Anonymous variable [BoolVar]>>"
         eq_(repr(tree), expected)
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import datetime
 import logging
 
-import datetime
-
-from nose.tools.trivial import ok_, eq_
+from nose.tools.trivial import eq_, ok_
 
 from booleano.utils import eval_boolean, get_boolean_evaluator
 
@@ -14,18 +13,22 @@ logger = logging.getLogger(__name__)
 
 class TestBooleanEval(object):
     def test_eval(self):
-        ok_(eval_boolean(
-            '"o" ∈ name & birthdate > "1983-02-02"',
-            {"name": "sokka", "age": 15, "birthdate": datetime.date(1984, 1, 1)},
-        ))
+        ok_(
+            eval_boolean(
+                '"o" ∈ name & birthdate > "1983-02-02"',
+                {"name": "sokka", "age": 15, "birthdate": datetime.date(1984, 1, 1)},
+            )
+        )
 
     def test_eval_grammar(self):
-        ok_(eval_boolean(
-            'age < const:majority & "o" in name & birthdate > "1983-02-02"',
-            {"name": "sokka", "age": 15, "birthdate": datetime.date(1984, 1, 1)},
-            {'majority': 18},
-            grammar_tokens={'belongs_to': 'in'}
-        ))
+        ok_(
+            eval_boolean(
+                'age < const:majority & "o" in name & birthdate > "1983-02-02"',
+                {"name": "sokka", "age": 15, "birthdate": datetime.date(1984, 1, 1)},
+                {"majority": 18},
+                grammar_tokens={"belongs_to": "in"},
+            )
+        )
 
     def test_eval_no_val(self):
         ok_(eval_boolean('"key" ∈ "keylogger"'))
@@ -46,8 +49,8 @@ class TestGetBooleanEvaluator(object):
         evaluator = get_boolean_evaluator(
             'age < const:majority & "o" in name & birthdate > "1983-02-02"',
             self.sample,
-            {'majority': 18},
-            grammar_tokens={'belongs_to': 'in'}
+            {"majority": 18},
+            grammar_tokens={"belongs_to": "in"},
         )
         for s, expected in zip(self.sample, (False, False, False, True)):
             eq_(evaluator(s), expected)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 minversion=1.8.0
 envlist =
-    py{27,34,35,36}
+    py{27,34,35,36,37,38,39}
     isort
     flake8
 


### PR DESCRIPTION
Major changes: 

- Removed the support for python2.7 since it's a deprecated python version now.
- Upgrade dependencies versions to be up to date and to avoid errors
- Upgrade contributing file to be up to date
- Fix linting and formatting according to new pep rules
- Refactoring some methods and variables for better readability